### PR TITLE
Menu city link fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ markdown: kramdown
 collections:
   miasta:
     output: true
+    permalink: /miasta/:path/
 
 exclude:
  - backup

--- a/_config.yml
+++ b/_config.yml
@@ -25,5 +25,4 @@ collections:
     permalink: /miasta/:path/
 
 exclude:
- - backup
  - bash


### PR DESCRIPTION
There are [several discussions about relative links in Jekyll on Github Pages](https://www.google.pl/?ion=1&espv=2#q=+github+pages+jekyll+collections+relative+links). I am unable to reproduce the issue on my local machine, so going to check it on living organism :japanese_ogre: 